### PR TITLE
Certificate folder links changed to care-group repo.

### DIFF
--- a/docs/part2/CERT1.md
+++ b/docs/part2/CERT1.md
@@ -31,7 +31,7 @@ Others (e.g. IBM Cloud) may allow you to generate your own self-signed certifica
 For example, mosquitto provides useful information on this page: https://test.mosquitto.org/ for mosquitto.
 Note also that mosquitto offer testing of secure connection with a deliberately expired server certificate, and will not allow you to generate and upload your own. 
 
-In the case you'd need to create your own certificate, you will be able to use the OpenSSL tool you installed in the prerequisite section, which allows you to work with certificates. I have provided 2 configuration files and 2 script files in the [certificates](https://github.com/binnes/esp8266Workshop/tree/master/certificates) folder of this git repo. You need to download them and have them in the directory you will use to generate the certificates. If you have cloned or downloaded the repo, then I suggest you work in the certificates directory.
+In the case you'd need to create your own certificate, you will be able to use the OpenSSL tool you installed in the prerequisite section, which allows you to work with certificates. I have provided 2 configuration files and 2 script files in the [certificates](https://github.com/care-group/ESP866-IoT-Workshop/tree/main/certificates) folder of this git repo. You need to download them and have them in the directory you will use to generate the certificates. If you have cloned or downloaded the repo, then I suggest you work in the certificates directory.
 
 The commands are provided to create text (pem) and binary (der) formats of the keys and certificates, as some device libraries require one or the other format. In this workshop we will only use the text versions of the certificates and keys.
 
@@ -117,7 +117,7 @@ xxd -i mqttServer_crt.der mqttServer_crt.der.h
 ```
 
 
-again substituting values for C=, ST=, L=, O=, OU= and CN=, but this time it is important that the CN value is the URL of your instance of the IoT messaging URL, which is the Organisation ID followed by **.messaging.internetofthings.ibmcloud.com**, which should also match the **subjectAltName** field in the [srvext.cfg](https://github.com/binnes/esp8266Workshop/blob/master/certificates/srvext.cfg) file.
+again substituting values for C=, ST=, L=, O=, OU= and CN=, but this time it is important that the CN value is the URL of your instance of the IoT messaging URL, which is the Organisation ID followed by **.messaging.internetofthings.ibmcloud.com**, which should also match the **subjectAltName** field in the [srvext.cfg](https://github.com/care-group/ESP866-IoT-Workshop/tree/main/certificates/srvext.cfg) file.
 
 The commands above generate a new key for the server, creates a certificate request for the server, issues the certificate and signs it with the root CA key, saving it as a pem file. The certificate is converted from pem to der format and lastly the xxd command creates a header file to embed the certificate in code.
 


### PR DESCRIPTION
Certificate folder links changed from unmaintained repo to care-group fork.  Note that the files in both certificate folders are currently identical.  Change is for future proofing only.